### PR TITLE
fix: Update Instance Login page to get the correct instance name

### DIFF
--- a/src/pages/Login/InstanceLogin/index.tsx
+++ b/src/pages/Login/InstanceLogin/index.tsx
@@ -15,7 +15,7 @@ export default function InstanceLogin() {
   const navigate = useNavigate();
 
   useEffect(() => {
-    const slug: string | undefined = location.pathname.split('/').pop();
+    const slug: string | undefined = location.pathname.split('/')[2];
 
     async function checkIfHaveAccess() {
       try {


### PR DESCRIPTION
Update Instance Login page to get the correct instance name